### PR TITLE
Update Matisse.

### DIFF
--- a/matisse/A10Lineage.xml
+++ b/matisse/A10Lineage.xml
@@ -9,14 +9,19 @@
 	<project name="android_device_samsung_matissewifi" path="device/samsung/matissewifi" remote="s3n" />
 	<project name="android_device_samsung_matisselte" path="device/samsung/matisselte" remote="s3n" />
 	<project name="android_device_samsung_matisse-common" path="device/samsung/matisse-common" remote="s3n" />
-	<project name="android_device_samsung_msm8226-common" path="device/samsung/msm8226-common" remote="s3n" />
+	<project name="LineageOS/android_device_samsung_msm8226-common" path="device/samsung/msm8226-common" remote="github" />
 	<project name="LineageOS/android_device_samsung_qcom-common" path="device/samsung/qcom-common" remote="github" revision="lineage-17.1" />
-	<project name="android_kernel_samsung_msm8226" path="kernel/samsung/msm8226" remote="s3n" />
+	<project name="LineageOS/android_kernel_samsung_msm8226" path="kernel/samsung/msm8226" remote="github" />
 	<project name="android_vendor_samsung_milet3g" path="vendor/samsung/milet3g" remote="s3n" />
 	<project name="android_vendor_samsung_matissewifi" path="vendor/samsung/matissewifi" remote="s3n" />
 	<project name="android_vendor_samsung_matisselte" path="vendor/samsung/matisselte" remote="s3n" />
 	<project name="android_vendor_samsung_matisse-common" path="vendor/samsung/matisse-common" remote="s3n" />
+	<project name="TheMuppets/proprietary_vendor_samsung" path="vendor/samsung" remote="github" revision="lineage-17.1" />
 
 	<!-- Dependencies -->
 	<project name="LineageOS/android_hardware_samsung" path="hardware/samsung" remote="github" revision="lineage-17.1" />
+	<project name="LineageOS/android_hardware_samsung" path="hardware/samsung" remote="github" revision="lineage-17.1" />
+  	<project name="LineageOS/android_external_stlport" path="external/stlport" remote="github" revision="lineage-15.1" />
+  	<project name="LineageOS/android_external_sony_boringssl-compat" path="external/sony/boringssl-compat" remote="github" revision="lineage-17.1" />
+  	<project name="LineageOS/android_hardware_sony_timekeep" path="hardware/sony/timekeep" remote="github" revision="lineage-17.1" />
 </manifest>


### PR DESCRIPTION
We no longer use the s3neo kernel, board, venor board repos as they are out of date matteo0026 we must know use the kernel, board from LineageOS  and board repos from the muppets.